### PR TITLE
updated GNOME runtime to 40 version

### DIFF
--- a/com.github.bajoja.indicator-kdeconnect.json
+++ b/com.github.bajoja.indicator-kdeconnect.json
@@ -1,7 +1,7 @@
 {
   "id": "com.github.bajoja.indicator-kdeconnect",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "40",
   "sdk": "org.gnome.Sdk",
   "command": "indicator-kdeconnect",
   "rename-desktop-file": "indicator-kdeconnect.desktop",

--- a/com.github.bajoja.indicator-kdeconnect.json
+++ b/com.github.bajoja.indicator-kdeconnect.json
@@ -1,7 +1,7 @@
 {
   "id": "com.github.bajoja.indicator-kdeconnect",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "40",
+  "runtime-version": "3.38",
   "sdk": "org.gnome.Sdk",
   "command": "indicator-kdeconnect",
   "rename-desktop-file": "indicator-kdeconnect.desktop",


### PR DESCRIPTION
Info: org.gnome.Platform//3.36 is end-of-life, with reason:
   The GNOME 3.36 runtime is no longer supported as of February 13, 2021. Please ask your application developer to migrate to a supported platform.